### PR TITLE
Reduce replica count to fit in default GKE cluster

### DIFF
--- a/example-workflows/gke-provision-and-deploy-workflow/deploy/deploy.yaml
+++ b/example-workflows/gke-provision-and-deploy-workflow/deploy/deploy.yaml
@@ -18,7 +18,7 @@ kind: Deployment
 metadata:
   name: nebula-example
 spec:
-  replicas: 3
+  replicas: 2
   template:
     metadata:
       labels:


### PR DESCRIPTION
The default GKE cluster size has ~2~ 1 vCPUs, so running a 3rd replica comes up as "unschedulable".