### PR TITLE
GKE cluster example: bumps the default node count to 2

### DIFF
--- a/example-workflows/gke-provision-and-deploy-workflow/infra/variables.tf
+++ b/example-workflows/gke-provision-and-deploy-workflow/infra/variables.tf
@@ -20,7 +20,7 @@ variable "google-credentials" {
 
 variable "initial_node_count" {
   description = "Number of worker VMs to initially create"
-  default = 1
+  default = 2
 }
 variable "node_machine_type" {
   description = "GCE machine type"


### PR DESCRIPTION
Related to #26 